### PR TITLE
Add `config.local.js` to permit config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# App
+packages/*/public/config.local.js

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # App Orders
 
 Commerce Layer application for managing orders.
+
+
+## Getting started
+
+```sh
+cp packages/app/public/config.local.example.js packages/app/public/config.local.js
+```

--- a/packages/app/global.d.ts
+++ b/packages/app/global.d.ts
@@ -2,7 +2,7 @@ export {}
 
 declare global {
   interface Window {
-    config: {
+    clAppConfig: {
       domain: string
     }
   }

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -17,6 +17,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.local.js"></script>
     <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/app/public/config.js
+++ b/packages/app/public/config.js
@@ -1,3 +1,6 @@
-window.config = {
-  domain: 'commercelayer.co'
-}
+window.clAppConfig = Object.assign(
+  {
+    domain: 'commercelayer.co'
+  },
+  window.clAppConfig
+)

--- a/packages/app/public/config.local.example.js
+++ b/packages/app/public/config.local.example.js
@@ -1,0 +1,1 @@
+window.clAppConfig = {}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -18,7 +18,7 @@ export function App(): JSX.Element {
       <TokenProvider
         clientKind='integration'
         currentApp='orders'
-        domain={window.config.domain}
+        domain={window.clAppConfig.domain}
         reauthenticateOnInvalidAuth={!isDev}
         devMode={isDev}
       >

--- a/packages/app/src/metricsApi/fetcher.ts
+++ b/packages/app/src/metricsApi/fetcher.ts
@@ -11,7 +11,7 @@ const metricsApiFetcher = async <Data>({
   accessToken,
   body
 }: MetricsApiFetcherParams): Promise<VndApiResponse<Data>> => {
-  const url = `https://${slug}.${window.config.domain}/metrics${endpoint}`
+  const url = `https://${slug}.${window.clAppConfig.domain}/metrics${endpoint}`
   const response = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
The configuration object has been renamed from `window.config` to `window.clAppConfig` to better identify the application scope.

A `config.local.js` file has been added (it's a git-ignored file). This file contains all the configuration overrides for your local environment and is automatically generated when deploying an artifact on a remote environment.