### PR TITLE
Replace `preact` with `react`

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,15 +13,18 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^0.0.7",
+    "@commercelayer/app-elements": "^0.0.8",
     "@commercelayer/sdk": "^4.25.0",
-    "preact": "^10.13.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "swr": "^2.1.0",
     "wouter": "^2.10.0"
   },
   "devDependencies": {
     "@commercelayer/eslint-config-ts-react": "^0.1.4",
-    "@preact/preset-vite": "^2.5.0",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^3.1.0",
     "eslint": "^8.35.0",
     "jsdom": "^21.1.0",
     "typescript": "^4.9.5",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -6,7 +6,6 @@ import {
   ErrorBoundary,
   TokenProvider
 } from '@commercelayer/app-elements'
-import type { JSX } from 'preact'
 import { Route, Router, Switch } from 'wouter'
 import { appRoutes } from './data/routes'
 

--- a/packages/app/src/components/ListItemOrder.tsx
+++ b/packages/app/src/components/ListItemOrder.tsx
@@ -9,7 +9,6 @@ import {
   useTokenProvider
 } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
-import type { JSX } from 'preact/jsx-runtime'
 import { Link } from 'wouter'
 
 interface Props {

--- a/packages/app/src/components/OrderAddresses.tsx
+++ b/packages/app/src/components/OrderAddresses.tsx
@@ -6,7 +6,6 @@ import {
   withinSkeleton
 } from '@commercelayer/app-elements'
 import type { Address, Order } from '@commercelayer/sdk'
-import type { JSX } from 'preact/jsx-runtime'
 
 interface Props {
   order: Order

--- a/packages/app/src/components/OrderCustomer.tsx
+++ b/packages/app/src/components/OrderCustomer.tsx
@@ -7,8 +7,7 @@ import {
   useCoreSdkProvider
 } from '@commercelayer/app-elements'
 import type { Customer, Order } from '@commercelayer/sdk'
-import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { JSX } from 'preact/jsx-runtime'
+import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
   order?: Order

--- a/packages/app/src/components/OrderLineItem.tsx
+++ b/packages/app/src/components/OrderLineItem.tsx
@@ -5,7 +5,6 @@ import {
   withinSkeleton
 } from '@commercelayer/app-elements'
 import type { LineItem } from '@commercelayer/sdk'
-import type { JSX } from 'preact/jsx-runtime'
 
 interface Props {
   lineItem: LineItem

--- a/packages/app/src/components/OrderShipments.tsx
+++ b/packages/app/src/components/OrderShipments.tsx
@@ -8,8 +8,7 @@ import {
   useCoreSdkProvider
 } from '@commercelayer/app-elements'
 import type { Order, Shipment } from '@commercelayer/sdk'
-import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { JSX } from 'preact/jsx-runtime'
+import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
   order: Order

--- a/packages/app/src/components/OrderSteps.tsx
+++ b/packages/app/src/components/OrderSteps.tsx
@@ -6,7 +6,6 @@ import {
   withinSkeleton
 } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
-import type { JSX } from 'preact/jsx-runtime'
 
 interface Props {
   order: Order

--- a/packages/app/src/components/OrderSummary.tsx
+++ b/packages/app/src/components/OrderSummary.tsx
@@ -1,6 +1,5 @@
 import { Legend, withinSkeleton } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
-import type { JSX } from 'preact/jsx-runtime'
 import { OrderLineItem } from './OrderLineItem'
 
 interface Props {

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,5 +1,10 @@
-import { render } from 'preact'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
 import { App } from './App'
 import '@commercelayer/app-elements/style.css'
 
-render(<App />, document.getElementById('root') as HTMLElement)
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/packages/app/src/pages/ErrorNotFound.tsx
+++ b/packages/app/src/pages/ErrorNotFound.tsx
@@ -1,6 +1,5 @@
 import { appRoutes } from '#data/routes'
 import { Button, EmptyState, PageLayout } from '@commercelayer/app-elements'
-import type { JSX } from 'preact/jsx-runtime'
 import { Link } from 'wouter'
 
 export function ErrorNotFound(): JSX.Element {

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -15,8 +15,7 @@ import {
   useTokenProvider
 } from '@commercelayer/app-elements'
 import type { LineItem, Order, Shipment } from '@commercelayer/sdk'
-import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { JSX } from 'preact/jsx-runtime'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useLocation, useRoute } from 'wouter'
 
 export function OrderDetails(): JSX.Element {

--- a/packages/app/src/pages/OrderHistory.tsx
+++ b/packages/app/src/pages/OrderHistory.tsx
@@ -1,3 +1,4 @@
+import { ListItemOrder } from '#components/ListItemOrder'
 import { appRoutes } from '#data/routes'
 import {
   List,
@@ -8,10 +9,8 @@ import {
 } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
 import type { ListResponse } from '@commercelayer/sdk/lib/cjs/resource'
-import { useEffect, useState } from 'preact/hooks'
-import type { JSX } from 'preact/jsx-runtime'
+import { useEffect, useState } from 'react'
 import { useLocation } from 'wouter'
-import { ListItemOrder } from '../components/ListItemOrder'
 
 export function OrderHistory(): JSX.Element {
   const {

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -9,8 +9,7 @@
     ],
     "types": [
       "vitest/globals",
-      "vite/client",
-      "preact"
+      "vite/client"
     ],
     "allowJs": false,
     "skipLibCheck": true,
@@ -28,15 +27,8 @@
     "noUnusedLocals": true,
     "importsNotUsedAsValues": "error",
     "jsx": "react-jsx",
-    "jsxImportSource": "preact",
     "baseUrl": "./",
     "paths": {
-      "react": [
-        "./node_modules/preact/compat/"
-      ],
-      "react-dom": [
-        "./node_modules/preact/compat/"
-      ],
       "#components/*": [
         "src/components/*"
       ],

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vitest/config'
-import preact from '@preact/preset-vite'
+import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [preact(), tsconfigPaths()],
+  plugins: [react(), tsconfigPaths()],
   base: '/orders',
   server: {
     fs: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,13 +18,16 @@ importers:
 
   packages/app:
     specifiers:
-      '@commercelayer/app-elements': ^0.0.7
+      '@commercelayer/app-elements': ^0.0.8
       '@commercelayer/eslint-config-ts-react': ^0.1.4
       '@commercelayer/sdk': ^4.25.0
-      '@preact/preset-vite': ^2.5.0
+      '@types/react': ^18.0.28
+      '@types/react-dom': ^18.0.11
+      '@vitejs/plugin-react': ^3.1.0
       eslint: ^8.35.0
       jsdom: ^21.1.0
-      preact: ^10.13.1
+      react: ^18.2.0
+      react-dom: ^18.2.0
       swr: ^2.1.0
       typescript: ^4.9.5
       vite: ^4.1.4
@@ -32,14 +35,17 @@ importers:
       vitest: ^0.28.5
       wouter: ^2.10.0
     dependencies:
-      '@commercelayer/app-elements': 0.0.7_@commercelayer+sdk@4.25.0
+      '@commercelayer/app-elements': 0.0.8_@commercelayer+sdk@4.25.0
       '@commercelayer/sdk': 4.25.0
-      preact: 10.13.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       swr: 2.1.0_react@18.2.0
       wouter: 2.10.0_react@18.2.0
     devDependencies:
       '@commercelayer/eslint-config-ts-react': 0.1.4_ezujzymwn6i6oisrjb2haixety
-      '@preact/preset-vite': 2.5.0_dukgwir26pnc5sb3oveyn54x3a
+      '@types/react': 18.0.28
+      '@types/react-dom': 18.0.11
+      '@vitejs/plugin-react': 3.1.0_vite@4.1.4
       eslint: 8.35.0
       jsdom: 21.1.0
       typescript: 4.9.5
@@ -99,13 +105,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
-    dev: true
-
-  /@babel/helper-annotate-as-pure/7.18.6:
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.2
     dev: true
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.21.0:
@@ -223,8 +222,8 @@ packages:
       '@babel/types': 7.21.2
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.21.0:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+  /@babel/plugin-transform-react-jsx-self/7.21.0_@babel+core@7.21.0:
+    resolution: {integrity: sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -233,28 +232,14 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.21.0:
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+  /@babel/plugin-transform-react-jsx-source/7.19.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
-    dev: true
-
-  /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.21.0:
-    resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.21.0
-      '@babel/types': 7.21.2
     dev: true
 
   /@babel/runtime/7.21.0:
@@ -299,8 +284,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@commercelayer/app-elements/0.0.7_@commercelayer+sdk@4.25.0:
-    resolution: {integrity: sha512-+YH0rhiHW+ms6JeqvlNGshKaXy7Cc/eDWbQEFzmGXXrPIjn+TrDm/tyVabTpMBRf/cQDIEVf8tPGD7M9Q/3AeQ==}
+  /@commercelayer/app-elements/0.0.8_@commercelayer+sdk@4.25.0:
+    resolution: {integrity: sha512-mzz7mU3+0cfxZs9t1KJ0ID0m89i6kmi4dvU8h22M6CG26wFLZ9lZzPYf6sQWzjT49tnHlA682FYnn7mYolz1PQ==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^4.x
@@ -1322,60 +1307,6 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@preact/preset-vite/2.5.0_dukgwir26pnc5sb3oveyn54x3a:
-    resolution: {integrity: sha512-BUhfB2xQ6ex0yPkrT1Z3LbfPzjpJecOZwQ/xJrXGFSZD84+ObyS//41RdEoQCMWsM0t7UHGaujUxUBub7WM1Jw==}
-    peerDependencies:
-      '@babel/core': 7.x
-      vite: 2.x || 3.x || 4.x
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.21.0
-      '@prefresh/vite': 2.2.9_preact@10.13.1+vite@4.1.4
-      '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2_@babel+core@7.21.0
-      debug: 4.3.4
-      kolorist: 1.7.0
-      resolve: 1.22.1
-      vite: 4.1.4
-    transitivePeerDependencies:
-      - preact
-      - supports-color
-    dev: true
-
-  /@prefresh/babel-plugin/0.4.4:
-    resolution: {integrity: sha512-/EvgIFMDL+nd20WNvMO0JQnzIl1EJPgmSaSYrZUww7A+aSdKsi37aL07TljrZR1cBMuzFxcr4xvqsUQLFJEukw==}
-    dev: true
-
-  /@prefresh/core/1.4.1_preact@10.13.1:
-    resolution: {integrity: sha512-og1vaBj3LMJagVncNrDb37Gqc0cWaUcDbpVt5hZtsN4i2Iwzd/5hyTsDHvlMirhSym3wL9ihU0Xa2VhSaOue7g==}
-    peerDependencies:
-      preact: ^10.0.0
-    dependencies:
-      preact: 10.13.1
-    dev: true
-
-  /@prefresh/utils/1.1.3:
-    resolution: {integrity: sha512-Mb9abhJTOV4yCfkXrMrcgFiFT7MfNOw8sDa+XyZBdq/Ai2p4Zyxqsb3EgHLOEdHpMj6J9aiZ54W8H6FTam1u+A==}
-    dev: true
-
-  /@prefresh/vite/2.2.9_preact@10.13.1+vite@4.1.4:
-    resolution: {integrity: sha512-1ERBF85Ja9/lkrfaltmo4Gca7R2ClQPSHHDDysFgfvPzHmLUeyB0x9WHwhwov/AA1DnyPhsfYT54z3yQd8XrgA==}
-    peerDependencies:
-      preact: ^10.4.0
-      vite: '>=2.0.0-beta.3'
-    dependencies:
-      '@babel/core': 7.21.0
-      '@prefresh/babel-plugin': 0.4.4
-      '@prefresh/core': 1.4.1_preact@10.13.1
-      '@prefresh/utils': 1.1.3
-      '@rollup/pluginutils': 4.2.1
-      preact: 10.13.1
-      vite: 4.1.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@rollup/plugin-replace/5.0.2:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
@@ -1388,14 +1319,6 @@ packages:
       '@rollup/pluginutils': 5.0.2
       magic-string: 0.27.0
     dev: false
-
-  /@rollup/pluginutils/4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
 
   /@rollup/pluginutils/5.0.2:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
@@ -1486,7 +1409,6 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: false
 
   /@types/react-datepicker/4.10.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-Cq+ks20vBIU6XN67TbkCHu8M7V46Y6vJrKE2n+8q/GfueJyWWTIKeC3Z7cz/d+qxGDq/VCrqA929R0U4lNuztg==}
@@ -1504,7 +1426,6 @@ packages:
     resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
     dependencies:
       '@types/react': 18.0.28
-    dev: false
 
   /@types/react-transition-group/4.4.5:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
@@ -1518,11 +1439,9 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-    dev: false
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: false
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
@@ -1656,6 +1575,22 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.1
       eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@vitejs/plugin-react/3.1.0_vite@4.1.4:
+    resolution: {integrity: sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.1.0-beta.0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/plugin-transform-react-jsx-self': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.0
+      magic-string: 0.27.0
+      react-refresh: 0.14.0
+      vite: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@vitest/expect/0.28.5:
@@ -1988,14 +1923,6 @@ packages:
       cosmiconfig: 7.1.0
       resolve: 1.22.1
     dev: false
-
-  /babel-plugin-transform-hook-names/1.0.2_@babel+core@7.21.0:
-    resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
-    peerDependencies:
-      '@babel/core': ^7.12.10
-    dependencies:
-      '@babel/core': 7.21.0
-    dev: true
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2623,7 +2550,6 @@ packages:
 
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-    dev: false
 
   /dargs/7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
@@ -3372,6 +3298,7 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: false
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -4653,10 +4580,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /kolorist/1.7.0:
-    resolution: {integrity: sha512-ymToLHqL02udwVdbkowNpzjFd6UzozMtshPQKVi5k1EjKRqKqBrOnE9QbLEb0/pV76SAiIT13hdL8R6suc+f3g==}
-    dev: true
-
   /latest-version/7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
@@ -4968,7 +4891,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: false
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -6176,9 +6098,6 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /preact/10.13.1:
-    resolution: {integrity: sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==}
-
   /prelude-ls/1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
     engines: {node: '>= 0.8.0'}
@@ -6407,6 +6326,11 @@ packages:
       react-fast-compare: 3.2.0
       warning: 4.0.3
     dev: false
+
+  /react-refresh/0.14.0:
+    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /react-select/5.7.0_zula6vjvt3wdocc4mwcxqa6nzi:
     resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}


### PR DESCRIPTION
Switch `React` in order to maximize compatibility with typings exported from `app-elements` package, which are default react types.