### PR TITLE
Enable refund when user can update transactions

### DIFF
--- a/packages/app/src/components/OrderDetailsContextMenu.tsx
+++ b/packages/app/src/components/OrderDetailsContextMenu.tsx
@@ -76,7 +76,7 @@ function getTriggerAttributesForUser(
   const onOrder: UITriggerAttributes[] = canUser('update', 'orders')
     ? ['_archive', '_unarchive']
     : []
-  const onCapture: UITriggerAttributes[] = canUser('update', 'captures')
+  const onCapture: UITriggerAttributes[] = canUser('update', 'transactions')
     ? ['_refund']
     : []
   return [...onOrder, ...onCapture]

--- a/packages/app/src/pages/Refund.tsx
+++ b/packages/app/src/pages/Refund.tsx
@@ -82,7 +82,7 @@ export function Refund(): JSX.Element {
   }
 
   if (
-    !canUser('update', 'captures') ||
+    !canUser('update', 'transactions') ||
     !isRefundable ||
     error != null ||
     order == null
@@ -92,7 +92,7 @@ export function Refund(): JSX.Element {
         <EmptyState
           title='Not found'
           description={
-            !canUser('update', 'captures')
+            !canUser('update', 'transactions')
               ? 'You are not authorized to access this page.'
               : 'Cannot make refund on this order'
           }


### PR DESCRIPTION
Scoping out the permissions required for the orders app, we identified that the right check to enable refund UI is on the update `transactions` capability.