### PR TITLE
Hide `_return` trigger attribute action

### DIFF
--- a/packages/app/src/components/OrderSummary.tsx
+++ b/packages/app/src/components/OrderSummary.tsx
@@ -35,7 +35,7 @@ export const OrderSummary = withSkeletonTemplate<Props>(
           footerActions={triggerAttributes
             .filter(
               (triggerAttribute) =>
-                !['_archive', '_unarchive', '_refund'].includes(
+                !['_archive', '_unarchive', '_refund', '_return'].includes(
                   triggerAttribute
                 )
             )


### PR DESCRIPTION
Returns will be handled from separate app, until then we'll hide the button