### PR TITLE
Fix typo

### DIFF
--- a/packages/app/src/data/filters.ts
+++ b/packages/app/src/data/filters.ts
@@ -31,7 +31,7 @@ export const instructions: FiltersInstructions = [
       props: {
         mode: 'multi',
         options: [
-          { value: 'placed', label: 'Places' },
+          { value: 'placed', label: 'Placed' },
           { value: 'approved', label: 'Approved' },
           { value: 'cancelled', label: 'Cancelled' }
         ]


### PR DESCRIPTION
## What I did

Fix small typo in filters page `Places` > `Placed`

 
