### PR TITLE
Hide timeline for pending orders

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@ac-dev/countries-service": "^1.2.0",
-    "@commercelayer/app-elements": "^0.0.62",
-    "@commercelayer/app-elements-hook-form": "^0.0.62",
+    "@commercelayer/app-elements": "^0.0.65",
+    "@commercelayer/app-elements-hook-form": "^0.0.65",
     "@commercelayer/sdk": "5.10.0",
     "@hookform/resolvers": "^3.1.1",
     "lodash": "^4.17.21",

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -113,9 +113,11 @@ export function OrderDetails(): JSX.Element {
           <Spacer top='14'>
             <OrderShipments order={order} />
           </Spacer>
-          <Spacer top='14'>
-            <OrderTimeline order={order} />
-          </Spacer>
+          {!['pending', 'draft'].includes(order.status) && (
+            <Spacer top='14'>
+              <OrderTimeline order={order} />
+            </Spacer>
+          )}
         </Spacer>
       </SkeletonTemplate>
     </PageLayout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@commercelayer/app-elements':
-        specifier: ^0.0.62
-        version: 0.0.62(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
+        specifier: ^0.0.65
+        version: 0.0.65(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
       '@commercelayer/app-elements-hook-form':
-        specifier: ^0.0.62
-        version: 0.0.62(@commercelayer/app-elements@0.0.62)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
+        specifier: ^0.0.65
+        version: 0.0.65(@commercelayer/app-elements@0.0.65)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
       '@commercelayer/sdk':
         specifier: 5.10.0
         version: 5.10.0
@@ -348,18 +348,18 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements-hook-form@0.0.62(@commercelayer/app-elements@0.0.62)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0):
-    resolution: {integrity: sha512-l2LdOC3R1p+Sx13CRLjAy7FmXoniC2EuMZloEFKSqb0b0EVz4Ru8qPoarw8tXb18Jxpum61vvhzkD5H2prI/Zw==}
+  /@commercelayer/app-elements-hook-form@0.0.65(@commercelayer/app-elements@0.0.65)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0):
+    resolution: {integrity: sha512-+t0RZ0xAe4DR1IwkxP7OxYwQuQSdtmDtU3KoqWlapnYal8n3jg+GxtlzXjoYIPALjCq6c01I1arznf+JXMY8Tw==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
-      '@commercelayer/app-elements': 0.0.62
+      '@commercelayer/app-elements': 0.0.65
       '@commercelayer/sdk': ^5.x
       query-string: ^8.1.x
       react: ^18.2.x
       react-dom: ^18.2.x
       react-hook-form: ^7.43.x
     dependencies:
-      '@commercelayer/app-elements': 0.0.62(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
+      '@commercelayer/app-elements': 0.0.65(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
       '@commercelayer/sdk': 5.10.0
       query-string: 8.1.0
       react: 18.2.0
@@ -367,8 +367,8 @@ packages:
       react-hook-form: 7.45.2(react@18.2.0)
     dev: false
 
-  /@commercelayer/app-elements@0.0.62(@commercelayer/sdk@5.10.0)(wouter@2.11.0):
-    resolution: {integrity: sha512-6PhmWG8EsgFTf3bwD3V7U64EbjkkHS8dKWrGFmXfp9fnjuKkGU83KN5WPub4DAu0yBEqtZZjRL9kZao+nvbI8A==}
+  /@commercelayer/app-elements@0.0.65(@commercelayer/sdk@5.10.0)(wouter@2.11.0):
+    resolution: {integrity: sha512-GSYL46O0obffBN0ocM6bdiVq1ePhfwiScXEc6Mwgsrj1Me5jv4ec67wuJS5FQ0erLtSvWL2GtiAnd6TNZFeQgg==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
## What I did
Prevent rendering of the timeline when order status is `pending`.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
