### PR TITLE
Remove dots when `card_last_digits` is not defined

### DIFF
--- a/packages/app/src/components/PaymentMethod.tsx
+++ b/packages/app/src/components/PaymentMethod.tsx
@@ -20,9 +20,11 @@ export function PaymentMethod({ order }: Props): JSX.Element {
           <span>
             {paymentInstrument.data.card_type}{' '}
             {paymentInstrument.data.issuer_type}
-            <Spacer left='2' style={{ display: 'inline-block' }}>
-              ··{paymentInstrument.data.card_last_digits}
-            </Spacer>
+            {paymentInstrument.data.card_last_digits != null && (
+              <Spacer left='2' style={{ display: 'inline-block' }}>
+                ··{paymentInstrument.data.card_last_digits}
+              </Spacer>
+            )}
           </span>
         ) : (
           paymentInstrument.data.issuer_type


### PR DESCRIPTION
## What I did

Before this change, there was "dots" in the payment method section:
<img width="330" alt="Screenshot 2023-08-14 alle 12 04 29" src="https://github.com/commercelayer/app-orders/assets/1681269/e458e38f-dc81-4c75-9891-2a5859e5a64c">

I removed these "dots" when `card_last_digits` is not defined.

See https://github.com/orgs/commercelayer/projects/36/views/1?pane=issue&itemId=35585348
