### PR TITLE
Add `gift_cards` to `<LineItems>` component

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@ac-dev/countries-service": "^1.2.0",
-    "@commercelayer/app-elements": "^0.0.66",
-    "@commercelayer/app-elements-hook-form": "^0.0.66",
+    "@commercelayer/app-elements": "^0.0.75",
+    "@commercelayer/app-elements-hook-form": "^0.0.75",
     "@commercelayer/sdk": "5.10.0",
     "@hookform/resolvers": "^3.1.1",
     "lodash": "^4.17.21",

--- a/packages/app/src/components/OrderAddresses.tsx
+++ b/packages/app/src/components/OrderAddresses.tsx
@@ -1,6 +1,5 @@
 import { appRoutes } from '#data/routes'
 import {
-  A,
   Legend,
   Spacer,
   Stack,
@@ -73,7 +72,7 @@ function renderAddress({
       </Spacer>
       {editUrl != null ? (
         <Link href={editUrl}>
-          <A>Edit</A>
+          <a>Edit</a>
         </Link>
       ) : null}
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,11 +23,11 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@commercelayer/app-elements':
-        specifier: ^0.0.66
-        version: 0.0.66(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
+        specifier: ^0.0.75
+        version: 0.0.75(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
       '@commercelayer/app-elements-hook-form':
-        specifier: ^0.0.66
-        version: 0.0.66(@commercelayer/app-elements@0.0.66)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
+        specifier: ^0.0.75
+        version: 0.0.75(@commercelayer/app-elements@0.0.75)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
       '@commercelayer/sdk':
         specifier: 5.10.0
         version: 5.10.0
@@ -344,18 +344,18 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements-hook-form@0.0.66(@commercelayer/app-elements@0.0.66)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0):
-    resolution: {integrity: sha512-duz5IPDRfNuJ9AKh2w2S7rHGrNAweOzonyUE85sgvla7uY6Y0ezhe4NvYTaVi0EB8yfn9hUmtJbd8F+/JvC/Yw==}
+  /@commercelayer/app-elements-hook-form@0.0.75(@commercelayer/app-elements@0.0.75)(@commercelayer/sdk@5.10.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0):
+    resolution: {integrity: sha512-/c57cCvjvlffK+uFNBSKuMr9GN7fOH2EwLx8NLYf3SN1lx4OU9i2MtCsUc2Lm6Ks43qWJ+8yZmA0hBUbZbf/SQ==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
-      '@commercelayer/app-elements': 0.0.66
+      '@commercelayer/app-elements': 0.0.75
       '@commercelayer/sdk': ^5.x
       query-string: ^8.1.x
       react: ^18.2.x
       react-dom: ^18.2.x
       react-hook-form: ^7.43.x
     dependencies:
-      '@commercelayer/app-elements': 0.0.66(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
+      '@commercelayer/app-elements': 0.0.75(@commercelayer/sdk@5.10.0)(wouter@2.11.0)
       '@commercelayer/sdk': 5.10.0
       query-string: 8.1.0
       react: 18.2.0
@@ -363,8 +363,8 @@ packages:
       react-hook-form: 7.45.2(react@18.2.0)
     dev: false
 
-  /@commercelayer/app-elements@0.0.66(@commercelayer/sdk@5.10.0)(wouter@2.11.0):
-    resolution: {integrity: sha512-ejsCNvNHcS3eADb9Kcx9v2WPEsy9on7uDPxgWh5NeDwxtRKWF0oHXSiOop5PKqFFaaaR4YgnGW+/fM78uWBmyQ==}
+  /@commercelayer/app-elements@0.0.75(@commercelayer/sdk@5.10.0)(wouter@2.11.0):
+    resolution: {integrity: sha512-vtYhnyLH4ZQAh2RO2jpQGDwPcvfhCwpA9PtN+JpvFz1FeaHzeSYz3c6PR3x2924r2/Lknei90mTniq1KuQ/TEw==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
## What I did

Update `app-elements` to latest [v0.0.75](https://github.com/commercelayer/app-elements/releases/tag/v0.0.75).

--- 

Add `gift_cards` to the `<LineItems>` component.

The gift card is visible only if the amount is greater than 0 (the customer bought it).

<img width="577" alt="Gift Card" src="https://github.com/commercelayer/app-orders/assets/1681269/ff1d4b60-16ca-4a9d-8a24-b82b62a02291">
