### PR TITLE
Add `tags` management and filterability

### DIFF
--- a/packages/app/src/data/filters.ts
+++ b/packages/app/src/data/filters.ts
@@ -126,6 +126,25 @@ export const instructions: FiltersInstructions = [
       }
     }
   },
+  {
+    label: 'Tags',
+    type: 'options',
+    sdk: {
+      predicate: 'tags_id_in'
+    },
+    render: {
+      component: 'relationshipSelector',
+      props: {
+        fieldForLabel: 'name',
+        fieldForValue: 'id',
+        resource: 'tags',
+        searchBy: 'name_cont',
+        sortBy: { attribute: 'name', direction: 'asc' },
+        previewLimit: 5,
+        showCheckboxIcon: false
+      }
+    }
+  },
 
   {
     label: 'Search',

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -105,7 +105,10 @@ export function OrderDetails(): JSX.Element {
               <ResourceTags
                 resourceType='orders'
                 resourceId={order.id}
-                overlay={{ title: pageTitle }}
+                overlay={{ title: 'Edit tags', description: pageTitle }}
+                onTagClick={(tagId) => {
+                  setLocation(appRoutes.list.makePath(`tags_id_in=${tagId}`))
+                }}
               />
             </Spacer>
           )}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- I added `tags` management in order detail to view and manage orders attached tags.
<img width="558" alt="Screenshot 2023-08-29 alle 12 06 54" src="https://github.com/commercelayer/app-orders/assets/105653649/86fe30c5-72b1-41e0-b052-a8e13cc82811">

- I updated filters to manage `tags` filterability and update `ResourceTags` component setup to let the selected tags acts as filters linking to the `list` page with the tag filter in the URL parameters.
<img width="554" alt="Screenshot 2023-08-29 alle 12 07 14" src="https://github.com/commercelayer/app-orders/assets/105653649/0acb8435-6e6f-4b9d-8c89-052a4b2c83d0">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
