### PR TITLE
Add `coupon_code` in the order summary by updating elements to v1.2.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ac-dev/countries-service": "^1.2.0",
-    "@commercelayer/app-elements": "^1.1.0",
+    "@commercelayer/app-elements": "^1.2.0",
     "@commercelayer/sdk": "5.15.0",
     "@hookform/resolvers": "^3.3.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@commercelayer/app-elements':
-        specifier: ^1.1.0
-        version: 1.1.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0)
+        specifier: ^1.2.0
+        version: 1.2.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0)
       '@commercelayer/sdk':
         specifier: 5.15.0
         version: 5.15.0
@@ -358,8 +358,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.1.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0):
-    resolution: {integrity: sha512-mi3c3q0RD3oV+7ZhIN9Wtv4NKaX8xJ5J+hDYVg7D8blobyf5eXI3j8Sj12gsv4IbN6miWBsCPx9i10tmjXN1IA==}
+  /@commercelayer/app-elements@1.2.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0):
+    resolution: {integrity: sha512-4nwX+U+aDh9zJQPc3gidxDegsSOqCWrAhP3p06RLSy6Ua8vjmGGnqlyF031kGG+al/TXARj+fsDr+aDxyNUAuA==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x
@@ -2000,6 +2000,17 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    dev: false
+
+  /axios@1.5.1:
+    resolution: {integrity: sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -5634,7 +5645,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.5.0
+      axios: 1.5.1
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1


### PR DESCRIPTION

## What I did

Add `coupon_code` in the order summary and explode all applied promotions by updating elements to [v1.2.0](https://github.com/commercelayer/app-elements/releases/tag/v1.2.0).

<img width="571" alt="Screenshot 2023-10-11 alle 10 59 30" src="https://github.com/commercelayer/app-orders/assets/1681269/8a311a97-5cfe-49f4-8269-26a0d30663ef">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
