### PR TITLE
Show all adjustment in the order summary by updating elements to v1.3.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ac-dev/countries-service": "^1.2.0",
-    "@commercelayer/app-elements": "^1.2.0",
+    "@commercelayer/app-elements": "^1.3.0",
     "@commercelayer/sdk": "5.15.0",
     "@hookform/resolvers": "^3.3.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@commercelayer/app-elements':
-        specifier: ^1.2.0
-        version: 1.2.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0)
+        specifier: ^1.3.0
+        version: 1.3.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0)
       '@commercelayer/sdk':
         specifier: 5.15.0
         version: 5.15.0
@@ -358,8 +358,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.2.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0):
-    resolution: {integrity: sha512-4nwX+U+aDh9zJQPc3gidxDegsSOqCWrAhP3p06RLSy6Ua8vjmGGnqlyF031kGG+al/TXARj+fsDr+aDxyNUAuA==}
+  /@commercelayer/app-elements@1.3.0(@commercelayer/sdk@5.15.0)(query-string@8.1.0)(react-dom@18.2.0)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.0):
+    resolution: {integrity: sha512-tSMDgzmeqiT0C5xydzEm8r6sGcr8nZYwIGw1hSkQ8//UaxGxhIRZE7R3+C2c+6F1rVjQkSElXU1rklhNv6bqrw==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
## What I did

I exploded all applied promotions by updating elements to [v1.3.0](https://github.com/commercelayer/app-elements/releases/tag/v1.3.0).

<img width="589" alt="Screenshot 2023-10-13 alle 15 10 36" src="https://github.com/commercelayer/app-orders/assets/1681269/ceeafd15-4ed7-41bc-8fbb-4f3a6244c08d">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
