### PR TITLE
Add `returns` support

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,3 +1,4 @@
+import { CreateReturn } from '#pages/CreateReturn'
 import { EditAddress } from '#pages/EditAddress'
 import { ErrorNotFound } from '#pages/ErrorNotFound'
 import { Filters } from '#pages/Filters'
@@ -59,6 +60,9 @@ export function App(): JSX.Element {
                 </Route>
                 <Route path={appRoutes.refund.path}>
                   <Refund />
+                </Route>
+                <Route path={appRoutes.return.path}>
+                  <CreateReturn />
                 </Route>
                 <Route>
                   <ErrorNotFound />

--- a/packages/app/src/components/FormFieldItems.tsx
+++ b/packages/app/src/components/FormFieldItems.tsx
@@ -1,0 +1,61 @@
+import {
+  Avatar,
+  HookedInputCheckboxGroup,
+  ListItem,
+  Text,
+  type HookedInputCheckboxGroupProps
+} from '@commercelayer/app-elements'
+
+import type { LineItem } from '@commercelayer/sdk'
+import { useMemo } from 'react'
+interface Props {
+  lineItems: LineItem[]
+}
+
+export function FormFieldItems({ lineItems }: Props): JSX.Element {
+  const options: HookedInputCheckboxGroupProps['options'] = useMemo(
+    () =>
+      lineItems.map((item) => ({
+        value: item.id,
+        content: (
+          <ListItem
+            alignIcon='center'
+            alignItems='center'
+            borderStyle='none'
+            icon={
+              item.image_url != null ? (
+                <Avatar
+                  alt={item.name ?? ''}
+                  size='small'
+                  src={item.image_url as `https://${string}`}
+                />
+              ) : undefined
+            }
+            padding='none'
+            tag='div'
+          >
+            <div>
+              <Text size='regular' tag='div' weight='bold'>
+                {item.name}
+              </Text>
+            </div>
+          </ListItem>
+        ),
+        quantity: {
+          min: 1,
+          max: item.quantity
+        }
+      })),
+    [lineItems]
+  )
+
+  if (options.length === 0) {
+    return <div>No items</div>
+  }
+
+  return (
+    <>
+      <HookedInputCheckboxGroup name='items' title='Items' options={options} />
+    </>
+  )
+}

--- a/packages/app/src/components/FormReturn.tsx
+++ b/packages/app/src/components/FormReturn.tsx
@@ -1,0 +1,99 @@
+import {
+  HookedValidationApiError,
+  Spacer,
+  useIsChanged
+} from '@commercelayer/app-elements'
+import { type LineItem } from '@commercelayer/sdk'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { forwardRef, useState } from 'react'
+import { FormProvider, useForm, type UseFormSetError } from 'react-hook-form'
+import { z } from 'zod'
+import { FormFieldItems } from './FormFieldItems'
+
+const returnFormSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        value: z.string().nonempty(),
+        quantity: z.number()
+      })
+    )
+    .superRefine((val, ctx) => {
+      if (val.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          minimum: 1,
+          type: 'array',
+          inclusive: true,
+          message: 'Please select at least one item'
+        })
+      }
+    })
+})
+
+export type ReturnFormValues = z.infer<typeof returnFormSchema>
+export type ReturnFormDefaultValues = z.input<typeof returnFormSchema>
+
+interface Props {
+  defaultValues: ReturnFormDefaultValues
+  onSubmit: (
+    formValues: ReturnFormValues,
+    setError: UseFormSetError<ReturnFormValues>
+  ) => void
+  apiError?: any
+  lineItems: LineItem[]
+}
+
+export const FormReturn = forwardRef<HTMLFormElement, Props>(
+  ({ onSubmit, defaultValues, apiError, lineItems }, ref) => {
+    const methods = useForm({
+      defaultValues,
+      resolver: zodResolver(returnFormSchema)
+    })
+
+    // when lineItems changes, we need to re-render the form
+    // to update defaults values for FormFieldItems
+    const [renderKey, setRenderKey] = useState(0)
+    useIsChanged({
+      value: lineItems,
+      onChange: () => {
+        setRenderKey(new Date().getTime())
+      }
+    })
+
+    useIsChanged({
+      value: defaultValues,
+      onChange: () => {
+        if (apiError == null) {
+          methods.reset(defaultValues)
+        }
+      }
+    })
+
+    const doSubmit = methods.handleSubmit(async (data) => {
+      onSubmit(data, methods.setError)
+    })
+
+    return (
+      <FormProvider {...methods} key={renderKey}>
+        <form
+          onSubmit={(e) => {
+            void doSubmit(e)
+          }}
+          ref={ref}
+          id='return-creation-form'
+        >
+          <Spacer bottom='12'>
+            <FormFieldItems lineItems={lineItems} />
+          </Spacer>
+          <HookedValidationApiError
+            apiError={apiError}
+            fieldMap={{
+              return_line_item: 'items'
+            }}
+          />
+        </form>
+      </FormProvider>
+    )
+  }
+)

--- a/packages/app/src/components/OrderDetailsContextMenu.tsx
+++ b/packages/app/src/components/OrderDetailsContextMenu.tsx
@@ -1,4 +1,5 @@
 import { appRoutes } from '#data/routes'
+import { useReturnableList } from '#hooks/useReturnableList'
 import { useTriggerAttribute } from '#hooks/useTriggerAttribute'
 import {
   Dropdown,
@@ -15,22 +16,38 @@ export const OrderDetailsContextMenu: FC<{ order: Order }> = ({ order }) => {
   const { canUser } = useTokenProvider()
   const [, setLocation] = useLocation()
 
+  const returnableLineItems = useReturnableList(order)
+  const showReturnDropDownItem =
+    canUser('create', 'returns') &&
+    order.fulfillment_status === 'fulfilled' &&
+    returnableLineItems.length > 0
+  const createReturnDropDownItem = useMemo(() => {
+    return showReturnDropDownItem ? (
+      <DropdownItem
+        key='request-return'
+        label='Request return'
+        onClick={() => {
+          setLocation(appRoutes.return.makePath(order.id))
+        }}
+      />
+    ) : undefined
+  }, [order, returnableLineItems])
+
   const { dispatch } = useTriggerAttribute(order.id)
 
-  const menuActions = useMemo(() => {
+  const excludedTriggerAttributes = ['_return']
+  const triggerMenuActions = useMemo(() => {
     const { triggerAttributes } = getOrderDisplayStatus(order)
-    return getTriggerAttributesForUser(canUser).filter((attr) =>
-      triggerAttributes.includes(attr)
+    return getTriggerAttributesForUser(canUser).filter(
+      (attr) =>
+        triggerAttributes.includes(attr) &&
+        !excludedTriggerAttributes.includes(attr)
     )
   }, [order])
 
-  if (menuActions.length === 0) {
-    return null
-  }
-
-  return (
-    <Dropdown
-      dropdownItems={menuActions.map((triggerAttribute) => (
+  const triggerDropDownItems = triggerMenuActions.map(
+    (triggerAttribute) =>
+      triggerAttribute !== '_return' && (
         <DropdownItem
           key={triggerAttribute}
           label={getOrderTriggerAttributeName(triggerAttribute)}
@@ -43,8 +60,19 @@ export const OrderDetailsContextMenu: FC<{ order: Order }> = ({ order }) => {
             void dispatch(triggerAttribute)
           }}
         />
-      ))}
-    />
+      )
+  )
+
+  if (!showReturnDropDownItem && triggerMenuActions.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Dropdown
+        dropdownItems={[createReturnDropDownItem, ...triggerDropDownItems]}
+      />
+    </>
   )
 }
 

--- a/packages/app/src/components/OrderReturns.tsx
+++ b/packages/app/src/components/OrderReturns.tsx
@@ -1,0 +1,72 @@
+import {
+  ResourceListItem,
+  Section,
+  navigateTo,
+  useTokenProvider,
+  withSkeletonTemplate
+} from '@commercelayer/app-elements'
+import type { Order, Return } from '@commercelayer/sdk'
+import type { SetNonNullable, SetRequired } from 'type-fest'
+
+interface Props {
+  order: Order
+}
+
+const returnStatuses = [
+  'requested',
+  'approved',
+  'cancelled',
+  'shipped',
+  'rejected',
+  'received'
+]
+
+const renderReturn: React.FC<Return> = (returnObj) => {
+  const {
+    canAccess,
+    settings: { mode }
+  } = useTokenProvider()
+
+  const navigateToReturn = canAccess('customers')
+    ? navigateTo({
+        destination: {
+          app: 'returns',
+          resourceId: returnObj.id,
+          mode
+        }
+      })
+    : {}
+
+  if (returnStatuses.includes(returnObj.status))
+    return (
+      <ResourceListItem
+        key={returnObj.id}
+        resource={returnObj}
+        {...navigateToReturn}
+      />
+    )
+}
+
+function hasReturns(
+  order: Order
+): order is SetRequired<SetNonNullable<Order, 'returns'>, 'returns'> {
+  return (
+    order.returns != null &&
+    order.returns.length > 0 &&
+    order.returns.filter((returnObj) =>
+      returnStatuses.includes(returnObj.status)
+    ).length > 0
+  )
+}
+
+export const OrderReturns = withSkeletonTemplate<Props>(({ order }) => {
+  if (!hasReturns(order)) {
+    return null
+  }
+
+  return (
+    <Section title='Returns'>
+      {order.returns.map((returnObj) => renderReturn(returnObj))}
+    </Section>
+  )
+})

--- a/packages/app/src/data/routes.ts
+++ b/packages/app/src/data/routes.ts
@@ -31,6 +31,10 @@ export const appRoutes = {
   refund: {
     path: '/list/:orderId/refund',
     makePath: (orderId: string) => `/list/${orderId}/refund`
+  },
+  return: {
+    path: '/list/:orderId/return',
+    makePath: (orderId: string) => `/list/${orderId}/return`
   }
 }
 

--- a/packages/app/src/hooks/useCreateReturnLineItems.tsx
+++ b/packages/app/src/hooks/useCreateReturnLineItems.tsx
@@ -1,0 +1,78 @@
+import { type ReturnFormValues } from '#components/FormReturn'
+import { useCoreSdkProvider } from '@commercelayer/app-elements'
+import type {
+  CommerceLayerClient,
+  Return,
+  ReturnLineItem
+} from '@commercelayer/sdk'
+import { useCallback, useState } from 'react'
+
+interface CreateReturnLineItemsHook {
+  isCreatingReturnLineItems: boolean
+  createReturnLineItemsError?: any
+  createReturnLineItems: (
+    returnObj: Return,
+    formValues: ReturnFormValues
+  ) => Promise<void>
+}
+
+export function useCreateReturnLineItems(): CreateReturnLineItemsHook {
+  const { sdkClient } = useCoreSdkProvider()
+
+  const [isCreatingReturnLineItems, setIsCreatingReturnLineItems] =
+    useState(false)
+  const [createReturnLineItemsError, setCreateReturnLineItemsError] =
+    useState<CreateReturnLineItemsHook['createReturnLineItemsError']>()
+
+  const createReturnLineItems: CreateReturnLineItemsHook['createReturnLineItems'] =
+    useCallback(async (returnObj, formValues) => {
+      setIsCreatingReturnLineItems(true)
+      setCreateReturnLineItemsError(undefined)
+      const returnLineItems: ReturnLineItem[] = []
+
+      try {
+        await Promise.all(
+          formValues.items.map(
+            async (item) =>
+              await sdkClient.return_line_items
+                .create({
+                  return: sdkClient.returns.relationship(returnObj?.id ?? null),
+                  quantity: item.quantity,
+                  line_item: sdkClient.line_items.relationship(item.value)
+                })
+                .then((lineItem) => returnLineItems.push(lineItem))
+          )
+        )
+        await sdkClient.returns.update({
+          id: returnObj.id,
+          _request: true
+        })
+      } catch (err) {
+        // delete line items and return if they were partially created
+        if (returnLineItems?.length > 0) {
+          await deleteReturnLineItems(returnLineItems, sdkClient)
+          await sdkClient.returns.delete(returnObj.id)
+        }
+        setCreateReturnLineItemsError(err)
+      } finally {
+        setIsCreatingReturnLineItems(false)
+      }
+    }, [])
+
+  return {
+    isCreatingReturnLineItems,
+    createReturnLineItemsError,
+    createReturnLineItems
+  }
+}
+
+async function deleteReturnLineItems(
+  lineItems: ReturnLineItem[],
+  sdkClient: CommerceLayerClient
+): Promise<void> {
+  await Promise.all(
+    lineItems.map(async (item) => {
+      await sdkClient.return_line_items.delete(item.id)
+    })
+  )
+}

--- a/packages/app/src/hooks/useOrderDetails.tsx
+++ b/packages/app/src/hooks/useOrderDetails.tsx
@@ -8,6 +8,10 @@ export const orderIncludeAttribute = [
   'shipping_address',
   'billing_address',
   'shipments',
+  'returns',
+  'returns.return_line_items',
+  'returns.origin_address',
+  'returns.destination_address',
   'payment_method',
   'payment_source'
 ]

--- a/packages/app/src/hooks/useReturn.tsx
+++ b/packages/app/src/hooks/useReturn.tsx
@@ -1,0 +1,48 @@
+import { isMock } from '#mocks'
+import { useCoreApi, useCoreSdkProvider } from '@commercelayer/app-elements'
+import type { Order, Return } from '@commercelayer/sdk'
+import { useEffect, useState } from 'react'
+
+export function useReturn(order: Order): Return | undefined {
+  const [returnObj, setReturnObj] = useState<Return>()
+  const [returnNeedsCreation, setReturnNeedsCreation] = useState(false)
+
+  const { sdkClient } = useCoreSdkProvider()
+  const { data: createdReturnObj } = useCoreApi(
+    'returns',
+    'create',
+    returnNeedsCreation
+      ? [
+          {
+            order: sdkClient.orders.relationship(order.id)
+          },
+          {
+            include: ['origin_address', 'destination_address']
+          }
+        ]
+      : null
+  )
+
+  useEffect(() => {
+    if (!isMock(order)) {
+      const draftReturnObject = order.returns?.filter(
+        (returnObj) =>
+          returnObj.status === 'draft' &&
+          (returnObj.return_line_items ?? []).length === 0
+      )[0]
+      if (draftReturnObject != null) {
+        setReturnObj(draftReturnObject)
+      } else {
+        setReturnNeedsCreation(true)
+      }
+    }
+  }, [order])
+
+  useEffect(() => {
+    if (createdReturnObj != null) {
+      setReturnObj(createdReturnObj)
+    }
+  }, [createdReturnObj])
+
+  return returnObj
+}

--- a/packages/app/src/hooks/useReturnableList.tsx
+++ b/packages/app/src/hooks/useReturnableList.tsx
@@ -1,0 +1,78 @@
+import { isMockedId } from '#mocks'
+import type {
+  LineItem,
+  Order,
+  Return,
+  ReturnLineItem
+} from '@commercelayer/sdk'
+import { useMemo } from 'react'
+
+function returnsToReturnLineItems(returns: Return[]): ReturnLineItem[] {
+  const returnLineItems: Record<string, ReturnLineItem> = {}
+
+  for (const returnObj of returns) {
+    for (const returnLineItem of returnObj.return_line_items ?? []) {
+      if (
+        returnObj.status === 'draft' ||
+        returnObj.status === 'cancelled' ||
+        (returnLineItem.sku_code == null && returnLineItem.bundle_code == null)
+      ) {
+        break
+      }
+
+      const returnLineItemKey =
+        returnLineItem.sku_code ?? returnLineItem.bundle_code
+
+      const currentReturnLineItem = returnLineItems[returnLineItemKey as string]
+
+      if (currentReturnLineItem != null) {
+        currentReturnLineItem.quantity += currentReturnLineItem.quantity
+      } else {
+        returnLineItems[returnLineItemKey as string] = {
+          ...returnLineItem,
+          type: 'return_line_items',
+          name: returnLineItem.name,
+          sku_code: returnLineItem.sku_code,
+          bundle_code: returnLineItem.bundle_code,
+          image_url: returnLineItem.image_url,
+          quantity: returnLineItem.quantity ?? 0
+        }
+      }
+    }
+  }
+
+  return Object.values(returnLineItems)
+}
+
+export function useReturnableList(order: Order): LineItem[] {
+  return useMemo(() => {
+    if (!isMockedId(order.id)) {
+      const returnLineItemsFromReturns = returnsToReturnLineItems(
+        order.returns ?? []
+      )
+      const returnableLineItems =
+        order.line_items
+          ?.filter(
+            (lineItem) =>
+              lineItem.item_type === 'skus' || lineItem.item_type === 'bundles'
+          )
+          ?.map((lineItem) => {
+            const returnLineItemQuantity: number =
+              returnLineItemsFromReturns.find(
+                (item) =>
+                  (item.sku_code != null &&
+                    item.sku_code === lineItem.sku_code) ||
+                  (item.bundle_code != null &&
+                    item.bundle_code === lineItem.bundle_code)
+              )?.quantity ?? 0
+            return {
+              ...lineItem,
+              quantity: lineItem.quantity - returnLineItemQuantity
+            }
+          })
+          .filter((lineItem) => lineItem.quantity > 0) ?? []
+      return returnableLineItems
+    }
+    return []
+  }, [order.line_items, order.returns])
+}

--- a/packages/app/src/pages/CreateReturn.tsx
+++ b/packages/app/src/pages/CreateReturn.tsx
@@ -1,0 +1,136 @@
+import { FormReturn } from '#components/FormReturn'
+import { ScrollToTop } from '#components/ScrollToTop'
+import { appRoutes } from '#data/routes'
+import { useCreateReturnLineItems } from '#hooks/useCreateReturnLineItems'
+import { useOrderDetails } from '#hooks/useOrderDetails'
+import { useReturn } from '#hooks/useReturn'
+import { useReturnableList } from '#hooks/useReturnableList'
+import { isMock } from '#mocks'
+import {
+  Button,
+  EmptyState,
+  PageLayout,
+  ResourceAddress,
+  Section,
+  SkeletonTemplate,
+  Spacer,
+  Stack,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import { Link, useLocation, useRoute } from 'wouter'
+
+export function CreateReturn(): JSX.Element {
+  const { canUser } = useTokenProvider()
+  const [, setLocation] = useLocation()
+  const [, params] = useRoute<{ orderId: string }>(appRoutes.return.path)
+
+  const orderId = params?.orderId
+  const goBackUrl =
+    orderId != null
+      ? appRoutes.details.makePath(orderId)
+      : appRoutes.home.makePath()
+
+  const { order, isLoading, mutateOrder } = useOrderDetails(orderId ?? '')
+  const returnObj = useReturn(order)
+
+  const returnableLineItems = useReturnableList(order)
+  const {
+    createReturnLineItemsError,
+    createReturnLineItems,
+    isCreatingReturnLineItems
+  } = useCreateReturnLineItems()
+
+  if (returnObj == null || isMock(order)) return <></>
+
+  if (
+    order.fulfillment_status !== 'fulfilled' ||
+    returnableLineItems.length === 0 ||
+    !canUser('create', 'returns')
+  ) {
+    return (
+      <PageLayout
+        title='Request return'
+        onGoBack={() => {
+          setLocation(goBackUrl)
+        }}
+      >
+        <EmptyState
+          title='Permission Denied'
+          description='You cannot create a return for this order or you are not authorized to access this page.'
+          action={
+            <Link href={goBackUrl}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout
+      title={
+        <SkeletonTemplate isLoading={isLoading}>
+          Request return
+        </SkeletonTemplate>
+      }
+      onGoBack={() => {
+        setLocation(goBackUrl)
+      }}
+    >
+      <ScrollToTop />
+      {returnableLineItems != null && returnableLineItems.length !== 0 && (
+        <>
+          <Spacer bottom='12'>
+            <FormReturn
+              defaultValues={{
+                items: returnableLineItems?.map((item) => ({
+                  quantity: item.quantity,
+                  value: item.id
+                }))
+              }}
+              lineItems={returnableLineItems}
+              apiError={createReturnLineItemsError}
+              onSubmit={(formValues) => {
+                void createReturnLineItems(returnObj, formValues).then(() => {
+                  void mutateOrder().finally(() => {
+                    setLocation(goBackUrl)
+                  })
+                })
+              }}
+            />
+          </Spacer>
+          {returnObj.origin_address != null &&
+            returnObj.destination_address != null && (
+              <Spacer bottom='12'>
+                <Section title='Addresses' border='none'>
+                  <Stack>
+                    <ResourceAddress
+                      title='Origin'
+                      resource={returnObj.origin_address}
+                      editable
+                      editPosition='bottom'
+                    />
+                    <ResourceAddress
+                      title='Destination'
+                      resource={returnObj.destination_address}
+                      editable
+                      editPosition='bottom'
+                    />
+                  </Stack>
+                </Section>
+              </Spacer>
+            )}
+          <Button
+            type='submit'
+            form='return-creation-form'
+            fullWidth
+            disabled={isCreatingReturnLineItems}
+          >
+            Request return
+          </Button>
+        </>
+      )}
+    </PageLayout>
+  )
+}

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -2,6 +2,7 @@ import { OrderAddresses } from '#components/OrderAddresses'
 import { OrderCustomer } from '#components/OrderCustomer'
 import { OrderDetailsContextMenu } from '#components/OrderDetailsContextMenu'
 import { OrderPayment } from '#components/OrderPayment'
+import { OrderReturns } from '#components/OrderReturns'
 import { OrderShipments } from '#components/OrderShipments'
 import { OrderSteps } from '#components/OrderSteps'
 import { OrderSummary } from '#components/OrderSummary'
@@ -129,6 +130,9 @@ export function OrderDetails(): JSX.Element {
           </Spacer>
           <Spacer top='14'>
             <OrderShipments order={order} />
+          </Spacer>
+          <Spacer top='14'>
+            <OrderReturns order={order} />
           </Spacer>
           {!['pending', 'draft'].includes(order.status) && (
             <Spacer top='14'>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Added `returns` section and list in order detail page.
<p><img src="https://github.com/commercelayer/app-orders/assets/105653649/1cc77ee9-bd76-42a7-813d-8a1d5021105d" alt="ReturnList" width="600" /></p>

- Added a custom `Request a return` menu item in the context menu of order detail page linked to a new `/list/<orderId>/return` page.
The menu item is visible only if the order is in `fulfillment_status`: `fulfilled` and if the current user is able to create a return.
<p><img src="https://github.com/commercelayer/app-orders/assets/105653649/07fbdcd4-3051-480b-90f7-d057d8d459cf" alt="RequestReturnMenuItem" width="600" /></p>

- Added the return submission page and form that enables the creation of a return by selecting returnable line item of current order with a valid quantity.
Once the page is opened a draft return will be created or selected, if already existing, in order to have `origin` and `destination` addresses editable during the submission flow.
<p><img src="https://github.com/commercelayer/app-orders/assets/105653649/43bf2df0-48e9-4793-ae08-2c2e7b1e95ae" alt="RequestReturnPage" width="600" /></p>


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
