### PR TITLE
Show `returns stock_location` in `returns list`

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ac-dev/countries-service": "^1.2.0",
-    "@commercelayer/app-elements": "^1.6.4",
+    "@commercelayer/app-elements": "1.6.5",
     "@commercelayer/sdk": "5.21.1",
     "@hookform/resolvers": "^3.3.2",
     "lodash": "^4.17.21",

--- a/packages/app/src/hooks/useOrderReturns.tsx
+++ b/packages/app/src/hooks/useOrderReturns.tsx
@@ -2,6 +2,7 @@ import { isMockedId } from '#mocks'
 import { useCoreApi } from '@commercelayer/app-elements'
 
 export const orderIncludeAttribute = [
+  'stock_location',
   'order',
   'order.market',
   'return_line_items'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@commercelayer/app-elements':
-        specifier: ^1.6.4
-        version: 1.6.4(@commercelayer/sdk@5.21.1)(query-string@8.1.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.1)
+        specifier: 1.6.5
+        version: 1.6.5(@commercelayer/sdk@5.21.1)(query-string@8.1.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.1)
       '@commercelayer/sdk':
         specifier: 5.21.1
         version: 5.21.1
@@ -362,8 +362,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.6.4(@commercelayer/sdk@5.21.1)(query-string@8.1.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.1):
-    resolution: {integrity: sha512-Qb1mJwyKS4MUR5cZ56xouosx+rdDB3lmStC6LjzDJQqnWFQ5RMb2Hq3ES8EC3CfS00ldJPeV6uvHPypiEVA9+w==}
+  /@commercelayer/app-elements@1.6.5(@commercelayer/sdk@5.21.1)(query-string@8.1.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.47.0)(react@18.2.0)(wouter@2.12.1):
+    resolution: {integrity: sha512-0ueq0ir6wQb5+JXbf3hencC/rU8LgmTRGLeUifeZ6xisMTROuNZ0nt05HdazrPI7FCO1+mNQy5GzoKCBtzpbbA==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Updated `app-elements` package to have `ResourceListItem` of type `returns` to show `stock_location` as destination info

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
