### PR TITLE
Add line item options

### DIFF
--- a/packages/app/src/hooks/useOrderDetails.tsx
+++ b/packages/app/src/hooks/useOrderDetails.tsx
@@ -5,6 +5,7 @@ export const orderIncludeAttribute = [
   'market',
   'customer',
   'line_items',
+  'line_items.line_item_options',
   'shipping_address',
   'billing_address',
   'shipments',


### PR DESCRIPTION
## What I did

Add missing include for `line_items.line_item_options` so that now is possible to show line item options in the order summary.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
