### PR TITLE
Fix Order detail back button behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   // format on save
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
   }
 }

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -131,30 +131,32 @@ export function Home(): JSX.Element {
                 <StatusIcon name='caretRight' />
               </ListItem>
             </Link>
-
-            <Link
-              href={appRoutes.list.makePath(
-                adapters.adaptFormValuesToUrlQuery({
-                  formValues: presets.editing
-                })
-              )}
-            >
-              <ListItem
-                tag='a'
-                icon={
-                  <StatusIcon
-                    name='pencilSimple'
-                    background='orange'
-                    gap='small'
-                  />
-                }
+            {counters?.editing != null && counters?.editing > 0 && (
+              <Link
+                href={appRoutes.list.makePath(
+                  adapters.adaptFormValuesToUrlQuery({
+                    formValues: presets.editing
+                  })
+                )}
               >
-                <Text weight='semibold'>
-                  {presets.editing.viewTitle} {formatCounter(counters?.editing)}
-                </Text>
-                <StatusIcon name='caretRight' />
-              </ListItem>
-            </Link>
+                <ListItem
+                  tag='a'
+                  icon={
+                    <StatusIcon
+                      name='pencilSimple'
+                      background='orange'
+                      gap='small'
+                    />
+                  }
+                >
+                  <Text weight='semibold'>
+                    {presets.editing.viewTitle}{' '}
+                    {formatCounter(counters?.editing)}
+                  </Text>
+                  <StatusIcon name='caretRight' />
+                </ListItem>
+              </Link>
+            )}
           </List>
         </Spacer>
 

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -24,7 +24,7 @@ import {
   goBack,
   useTokenProvider
 } from '@commercelayer/app-elements'
-import { Link, useLocation, useRoute } from 'wouter'
+import { useLocation, useRoute } from 'wouter'
 
 export function OrderDetails(): JSX.Element {
   const {
@@ -59,9 +59,17 @@ export function OrderDetails(): JSX.Element {
         <EmptyState
           title='Not authorized'
           action={
-            <Link href={appRoutes.home.makePath()}>
-              <Button variant='primary'>Go back</Button>
-            </Link>
+            <Button
+              variant='primary'
+              onClick={() => {
+                goBack({
+                  setLocation,
+                  defaultRelativePath: appRoutes.home.makePath()
+                })
+              }}
+            >
+              Go back
+            </Button>
           }
         />
       </PageLayout>

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -21,6 +21,7 @@ import {
   SkeletonTemplate,
   Spacer,
   formatDateWithPredicate,
+  goBack,
   useTokenProvider
 } from '@commercelayer/app-elements'
 import { Link, useLocation, useRoute } from 'wouter'
@@ -45,9 +46,12 @@ export function OrderDetails(): JSX.Element {
         title='Orders'
         navigationButton={{
           onClick: () => {
-            setLocation(appRoutes.home.makePath())
+            goBack({
+              setLocation,
+              defaultRelativePath: appRoutes.home.makePath()
+            })
           },
-          label: 'Orders',
+          label: 'Back',
           icon: 'arrowLeft'
         }}
         mode={mode}
@@ -97,9 +101,12 @@ export function OrderDetails(): JSX.Element {
       }
       navigationButton={{
         onClick: () => {
-          setLocation(appRoutes.home.makePath())
+          goBack({
+            setLocation,
+            defaultRelativePath: appRoutes.home.makePath()
+          })
         },
-        label: 'Orders',
+        label: 'Back',
         icon: 'arrowLeft'
       }}
       gap='only-top'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Fixed Order Detail page back button behavior by restoring the `goBack` helper
- Home page `Editing` view was hidden if counter is 0

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
