### PR TITLE
Add `asChild` prop to wouter `Link`

### DIFF
--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -63,6 +63,7 @@ export function Home(): JSX.Element {
                   formValues: presets.awaitingApproval
                 })
               )}
+              asChild
             >
               <ListItem
                 tag='a'
@@ -88,6 +89,7 @@ export function Home(): JSX.Element {
                   formValues: presets.paymentToCapture
                 })
               )}
+              asChild
             >
               <ListItem
                 tag='a'
@@ -113,6 +115,7 @@ export function Home(): JSX.Element {
                   formValues: presets.fulfillmentInProgress
                 })
               )}
+              asChild
             >
               <ListItem
                 tag='a'
@@ -138,6 +141,7 @@ export function Home(): JSX.Element {
                     formValues: presets.editing
                   })
                 )}
+                asChild
               >
                 <ListItem
                   tag='a'
@@ -168,6 +172,7 @@ export function Home(): JSX.Element {
                   formValues: presets.history
                 })
               )}
+              asChild
             >
               <ListItem
                 tag='a'
@@ -189,6 +194,7 @@ export function Home(): JSX.Element {
                   formValues: presets.pending
                 })
               )}
+              asChild
             >
               <ListItem tag='a' icon={<RadialProgress size='small' />}>
                 <Text weight='semibold'>{presets.pending.viewTitle}</Text>
@@ -201,6 +207,7 @@ export function Home(): JSX.Element {
                   formValues: presets.archived
                 })
               )}
+              asChild
             >
               <ListItem
                 tag='a'


### PR DESCRIPTION
## What I did

In wouter 3.0 wrapping an `<a>` tag inside a  `<Link>`  components created double `<a>` tags, as explained here:
https://github.com/molefrog/wouter/releases/tag/v3.0.0 (see `Link composition with asChild prop`).

So in this PR I've added the `asChild` where needed.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
