### PR TITLE
Relax node version to work with Vercel deploy button

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=20",
+    "node": ">=18",
     "pnpm": ">=8"
   },
   "workspaces": [

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -26,7 +26,7 @@ You need a local Node.JS (version 18+) environment and some React.JS knowledge t
 git clone https://github.com/<your username>/app-orders.git && cd app-orders
 ```
 
-3. Set your environment by creating a new `/src/app/.env.local` file starting from `/src/app/.env.local.sample` (not required for local development).
+3. Set your environment by creating a new `/src/app/.env.local` file starting from `/src/app/.env` (not required for local development).
 
 4. Install dependencies and run the development server:
 


### PR DESCRIPTION
## What I did

By default Vercel starts a project with Node 18, so we want this to match the instructions in package.json or the quick deploy button won't work.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
