### PR TITLE
Increase debounce delay in text search

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^1.16.0",
+    "@commercelayer/app-elements": "^1.17.2",
     "@commercelayer/sdk": "5.33.1",
     "@hookform/resolvers": "^3.3.4",
     "lodash": "^4.17.21",

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -34,6 +34,7 @@ function Home(): JSX.Element {
           setLocation(appRoutes.list.makePath({}, qs))
         }}
         queryString={search}
+        searchBarDebounceMs={1500}
       />
 
       <SkeletonTemplate isLoading={isLoadingCounters}>

--- a/packages/app/src/pages/OrderList.tsx
+++ b/packages/app/src/pages/OrderList.tsx
@@ -55,6 +55,7 @@ function OrderList(): JSX.Element {
           setLocation(appRoutes.filters.makePath({}, queryString))
         }}
         hideFiltersNav={hideFiltersNav}
+        searchBarDebounceMs={1500}
       />
 
       <Spacer bottom='14'>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   packages/app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^1.16.0
-        version: 1.16.0(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1)
+        specifier: ^1.17.2
+        version: 1.17.2(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1)
       '@commercelayer/sdk':
         specifier: 5.33.1
         version: 5.33.1
@@ -358,8 +358,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.16.0(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1):
-    resolution: {integrity: sha512-Ug4S3sW0ctseMfVshlm+PoLPFV5Kbxd5ACxpNDYfMtW6LyQyVgY8f3lZxlkA8hG/GhHXenMW6SRni61XPya02Q==}
+  /@commercelayer/app-elements@1.17.2(@commercelayer/sdk@5.33.1)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.0)(react@18.2.0)(wouter@3.0.1):
+    resolution: {integrity: sha512-/tgUwxomUl+rB/YePOMjl1C1N5r86F/ZjWNCOgPcljvefa4piJ6zQbbXZILggiHOfJ1reJwcWen2C1Gfjq51QQ==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
## What I did

Filter text search now is debounced at 1,5 seconds.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
