### PR TITLE
Allow to fetch pending orders with Metrics API

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^1.21.1",
+    "@commercelayer/app-elements": "^1.22.0",
     "@commercelayer/sdk": "5.37.0",
     "@hookform/resolvers": "^3.3.4",
     "lodash": "^4.17.21",

--- a/packages/app/src/data/filters.ts
+++ b/packages/app/src/data/filters.ts
@@ -1,6 +1,10 @@
 import type { FiltersInstructions } from '@commercelayer/app-elements'
 
-export const instructions: FiltersInstructions = [
+export const makeInstructions = ({
+  sortByAttribute = 'placed_at'
+}: {
+  sortByAttribute?: 'placed_at' | 'created_at'
+}): FiltersInstructions => [
   {
     label: 'Markets',
     type: 'options',
@@ -109,7 +113,7 @@ export const instructions: FiltersInstructions = [
     label: 'Time Range',
     type: 'timeRange',
     sdk: {
-      predicate: 'placed_at'
+      predicate: sortByAttribute
     },
     render: {
       component: 'dateRangePicker'

--- a/packages/app/src/data/lists.ts
+++ b/packages/app/src/data/lists.ts
@@ -40,7 +40,7 @@ export const presets: Record<ListType, FormFullValues> = {
   },
   pending: {
     status_in: ['pending'],
-    archived: 'hide',
+    archived: 'show',
     viewTitle: 'Pending orders'
   },
   archived: {

--- a/packages/app/src/pages/Filters.tsx
+++ b/packages/app/src/pages/Filters.tsx
@@ -1,4 +1,4 @@
-import { instructions } from '#data/filters'
+import { makeInstructions } from '#data/filters'
 import { appRoutes } from '#data/routes'
 import { PageLayout, useResourceFilters } from '@commercelayer/app-elements'
 import { useLocation } from 'wouter'
@@ -6,7 +6,7 @@ import { useLocation } from 'wouter'
 function Filters(): JSX.Element {
   const [, setLocation] = useLocation()
   const { FiltersForm, adapters } = useResourceFilters({
-    instructions
+    instructions: makeInstructions({})
   })
 
   const searchParams = new URLSearchParams(location.search)

--- a/packages/app/src/pages/Home.tsx
+++ b/packages/app/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { instructions } from '#data/filters'
+import { makeInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -22,7 +22,7 @@ function Home(): JSX.Element {
   const { data: counters, isLoading: isLoadingCounters } = useListCounters()
 
   const { adapters, SearchWithNav } = useResourceFilters({
-    instructions
+    instructions: makeInstructions({})
   })
 
   return (

--- a/packages/app/src/pages/OrderList.tsx
+++ b/packages/app/src/pages/OrderList.tsx
@@ -1,6 +1,6 @@
 import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemOrder } from '#components/ListItemOrder'
-import { instructions } from '#data/filters'
+import { makeInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -20,9 +20,15 @@ function OrderList(): JSX.Element {
   const queryString = useSearch()
   const [, setLocation] = useLocation()
 
+  const isPendingOrdersList =
+    new URLSearchParams(queryString).get('viewTitle') ===
+    presets.pending.viewTitle
+
   const { SearchWithNav, FilteredList, viewTitle, hasActiveFilter } =
     useResourceFilters({
-      instructions
+      instructions: makeInstructions({
+        sortByAttribute: isPendingOrdersList ? 'created_at' : 'placed_at'
+      })
     })
 
   const isUserCustomFiltered =
@@ -55,6 +61,7 @@ function OrderList(): JSX.Element {
           setLocation(appRoutes.filters.makePath({}, queryString))
         }}
         hideFiltersNav={hideFiltersNav}
+        hideSearchBar={viewTitle === presets.pending.viewTitle}
         searchBarDebounceMs={1000}
       />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   packages/app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^1.21.1
-        version: 1.21.1(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2)
+        specifier: ^1.22.0
+        version: 1.22.0(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2)
       '@commercelayer/sdk':
         specifier: 5.37.0
         version: 5.37.0
@@ -361,8 +361,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.21.1(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2):
-    resolution: {integrity: sha512-vJ1cpm8nEC4S+JQlgMNu5238UW04Rzn2JaZIeFRyDELqNuNtWRp3Cq4C3E1BdDODKSYnG/o4It2d7F5t0X3ITg==}
+  /@commercelayer/app-elements@1.22.0(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2):
+    resolution: {integrity: sha512-BxxDli3MM/4PzNRU7kTpvTYqDHP2YMgNRMvVABmGZYeuMNHzeMwB2lEhbr8BvaaJAPnHnUF8o7u/+mzhvBfgNw==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've updated `app-elements` to the latest version to fix the listing of pending orders.
I've also also modified the filter instructions to use `created_at` as date predicate instead of `placed_at` when listing pending orders.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
