### PR TITLE
Update elements and set metadata mode simple

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^1.22.0",
+    "@commercelayer/app-elements": "^1.22.1",
     "@commercelayer/sdk": "5.37.0",
     "@hookform/resolvers": "^3.3.4",
     "lodash": "^4.17.21",

--- a/packages/app/src/pages/OrderDetails.tsx
+++ b/packages/app/src/pages/OrderDetails.tsx
@@ -166,6 +166,7 @@ function OrderDetails(): JSX.Element {
                 overlay={{
                   title: pageTitle
                 }}
+                mode='simple'
               />
             </Spacer>
           )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   packages/app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^1.22.0
-        version: 1.22.0(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2)
+        specifier: ^1.22.1
+        version: 1.22.1(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2)
       '@commercelayer/sdk':
         specifier: 5.37.0
         version: 5.37.0
@@ -361,8 +361,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.22.0(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2):
-    resolution: {integrity: sha512-BxxDli3MM/4PzNRU7kTpvTYqDHP2YMgNRMvVABmGZYeuMNHzeMwB2lEhbr8BvaaJAPnHnUF8o7u/+mzhvBfgNw==}
+  /@commercelayer/app-elements@1.22.1(@commercelayer/sdk@5.37.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.2):
+    resolution: {integrity: sha512-E9Khwf+e3xW6MHUqvmQE5JdXQ7O1fLObwykzfZUX+R71OxTuc9tir/iJ/wlqz3At3CGQUSTyL+ZlgRNhMwopAA==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Update `app-elements` to fix `ResourceMetadata` and temporarily set `ResourceMetadata` component to mode `simple`. We need to improve consistency of the `advanced` mode.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
