### PR TITLE
Hide archived orders from open lists

### DIFF
--- a/packages/app/src/data/lists.ts
+++ b/packages/app/src/data/lists.ts
@@ -13,7 +13,7 @@ export const presets: Record<ListType, FormFullValues> = {
   awaitingApproval: {
     status_in: ['placed'],
     payment_status_in: ['authorized', 'free', 'paid'],
-    archived: 'show',
+    archived: 'hide',
     viewTitle: 'Awaiting approval'
   },
   editing: {
@@ -25,13 +25,13 @@ export const presets: Record<ListType, FormFullValues> = {
   paymentToCapture: {
     status_in: ['approved'],
     payment_status_in: ['authorized'],
-    archived: 'show',
+    archived: 'hide',
     viewTitle: 'Payment to capture'
   },
   fulfillmentInProgress: {
     status_in: ['approved'],
     fulfillment_status_in: ['in_progress'],
-    archived: 'show',
+    archived: 'hide',
     viewTitle: 'Fulfillment in progress'
   },
   history: {


### PR DESCRIPTION
Closes #176

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've configured the presets with `archived: false` for all the main lists.
Now archived orders are only listed in the archived section (and carts)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
