### PR TITLE
Sort order list by `placed_at`

### DIFF
--- a/packages/app/src/pages/OrderList.tsx
+++ b/packages/app/src/pages/OrderList.tsx
@@ -70,7 +70,9 @@ function OrderList(): JSX.Element {
             search: {
               limit: 25,
               sort: 'desc',
-              sort_by: 'order.updated_at',
+              sort_by: isPendingOrdersList
+                ? 'order.updated_at'
+                : 'order.placed_at',
               fields: ['order.*', 'billing_address.*', 'market.*']
             }
           }}


### PR DESCRIPTION
Closes commercelayer/issues-app#142

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Sort order list by `placed_at`.