### PR TITLE
Update action button labels + show the shipping and payment method names

### DIFF
--- a/packages/app/src/components/OrderSummary/SummaryRows.tsx
+++ b/packages/app/src/components/OrderSummary/SummaryRows.tsx
@@ -95,7 +95,7 @@ export const SummaryRows: React.FC<{ order: Order; editable: boolean }> = ({
       )
 
     return renderTotalRow({
-      label: 'Shipping method',
+      label: order.shipments?.[0]?.shipping_method?.name ?? 'Shipping method',
       value:
         canEditShipments && !hasInvalidShipments ? (
           <>
@@ -131,7 +131,7 @@ export const SummaryRows: React.FC<{ order: Order; editable: boolean }> = ({
       })}
       {shippingMethodRow}
       {renderTotalRowAmount({
-        label: 'Payment method',
+        label: order.payment_method?.name ?? 'Payment method',
         amountCents: order.payment_method_amount_cents,
         formattedAmount: order.formatted_payment_method_amount
       })}

--- a/packages/app/src/components/OrderSummary/hooks/useActionButtons.tsx
+++ b/packages/app/src/components/OrderSummary/hooks/useActionButtons.tsx
@@ -85,7 +85,7 @@ export const useActionButtons = ({ order }: { order: Order }) => {
     }
 
     const continueAction: ActionButtonsProps['actions'][number] = {
-      label: 'Continue',
+      label: 'Continue editing',
       disabled: isLoading || !hasLineItems,
       onClick: () => {
         showSelectShippingMethodOverlay()

--- a/packages/app/src/components/OrderSummary/orderDictionary.ts
+++ b/packages/app/src/components/OrderSummary/orderDictionary.ts
@@ -73,7 +73,7 @@ export function getTriggerAttributeName(
   const dictionary: Record<typeof triggerAttribute, string> = {
     _approve: 'Approve',
     _archive: 'Archive',
-    _cancel: 'Cancel',
+    _cancel: 'Cancel order',
     _capture: 'Capture payment',
     _refund: 'Refund',
     _unarchive: 'Unarchive'


### PR DESCRIPTION
Closes commercelayer/issues-app#133
Closes commercelayer/issues-app#129

## What I did

I update the action labels:

- Cancel → Cancel Order
- Continue → Continue Editing
- Show the shipping method name and payment method name instead of "shipping costs" only