### PR TITLE
Rollback shipping method name change

### DIFF
--- a/packages/app/src/components/OrderSummary/SummaryRows.tsx
+++ b/packages/app/src/components/OrderSummary/SummaryRows.tsx
@@ -95,7 +95,7 @@ export const SummaryRows: React.FC<{ order: Order; editable: boolean }> = ({
       )
 
     return renderTotalRow({
-      label: order.shipments?.[0]?.shipping_method?.name ?? 'Shipping method',
+      label: 'Shipping method',
       value:
         canEditShipments && !hasInvalidShipments ? (
           <>


### PR DESCRIPTION
## What I did

I changed the shipping method label back to "Shipping method".
